### PR TITLE
Only use ActionDispatch::Static if Rails serves static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,21 @@ Steps for updating the included Universal Viewer
 
 1. Make sure you have **npm** and **bower** installed: https://bower.io/
 1. Insert a reference to the latest tagged version of the Princeton branded viwer in [bower.json](https://github.com/pulibrary/pul_uv_rails/blob/master/bower.json#L25).
-1. Update using bower: 
-  
+1. Update using bower:
+
    ```
-  $ bower update
+   $ bower update
    ```
+
 1. Commit the changes and tag pul_uv_rails with the updated version.
 
 ## Edit Viewer Style
 
 1. Make changes to the less files in the [PUL Universal Viewer theme](https://github.com/pulibrary/uv-en-GB-theme).
-1. Rebuild the [viewer libary](https://github.com/pulibrary/universalviewer):
+1. Rebuild the [viewer library](https://github.com/pulibrary/universalviewer):
 
    ```
    $ grunt build
    ```
+
 1. Commit changes to the viewer and tag.

--- a/lib/pul_uv_rails.rb
+++ b/lib/pul_uv_rails.rb
@@ -4,7 +4,9 @@ require 'pul_uv_rails/universal_viewer'
 module PulUvRails
   class Engine < ::Rails::Engine
     initializer 'static assets' do |app|
-      app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public")
+      if Rails.application.config.public_file_server.enabled
+        app.middleware.insert_before(::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public")
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #1 by only using the `ActionDispatch::Static` middleware should Rails be configured to serve static assets